### PR TITLE
[feat/4] 프로그래머스 SQL 카테고리 추가

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,6 +6,7 @@ enum SiteHost {
 enum SiteType {
   BOJ = "BOJ",
   PROGRAMMERS = "PROGRAMMERS",
+  PROGRAMMERS_SQL = "PROGRAMMERS_SQL",
   SWEA = "SWEA",
 }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -36,6 +36,7 @@ const Utils = {
       case SiteType.BOJ:
         return "/logo/baekjoon_logo.png";
       case SiteType.PROGRAMMERS:
+      case SiteType.PROGRAMMERS_SQL:
         return "/logo/programmers_logo.png";
     }
   },

--- a/src/contentScript/programmers.ts
+++ b/src/contentScript/programmers.ts
@@ -19,10 +19,9 @@ const convertLevelEmoji = (level: number) => {
 
 const parseProblemInformation = () => {
   const content = document.querySelector(".main > .lesson-content");
+  const category = content.getAttribute("data-challenge-category").trim().toLowerCase();
   const source =
-    content.getAttribute("data-challenge-category").trim() !== "database"
-      ? SiteType.PROGRAMMERS
-      : SiteType.PROGRAMMERS_SQL;
+    category !== "database" && category !== "sql" ? SiteType.PROGRAMMERS : SiteType.PROGRAMMERS_SQL;
   const level = content.getAttribute("data-challenge-level");
   const problemNumber = content.getAttribute("data-lesson-id");
   const problemTitle = content.getAttribute("data-lesson-title").trim();

--- a/src/contentScript/programmers.ts
+++ b/src/contentScript/programmers.ts
@@ -19,10 +19,16 @@ const convertLevelEmoji = (level: number) => {
 
 const parseProblemInformation = () => {
   const content = document.querySelector(".main > .lesson-content");
+  const source =
+    content.getAttribute("data-challenge-category").trim() !== "database"
+      ? SiteType.PROGRAMMERS
+      : SiteType.PROGRAMMERS_SQL;
   const level = content.getAttribute("data-challenge-level");
   const problemNumber = content.getAttribute("data-lesson-id");
   const problemTitle = content.getAttribute("data-lesson-title").trim();
+
   return {
+    source,
     level,
     problemNumber,
     problemTitle,
@@ -31,11 +37,11 @@ const parseProblemInformation = () => {
 
 const programmers = async () => {
   try {
-    const { level, problemNumber, problemTitle } = parseProblemInformation();
+    const { source, level, problemNumber, problemTitle } = parseProblemInformation();
     return {
       isExist: true,
       problemPage: new ProblemPage(
-        SiteType.PROGRAMMERS,
+        source,
         convertLevelTier(Number(level)),
         problemNumber,
         problemTitle,


### PR DESCRIPTION
## Work Description

- 프로그래머스 SQL 카테고리를 기존의 프로그래머스 카테고리와 분리합니다.
- 문제의 카테고리가 'sql'인 경우와 'database'인 경우를 프로그래머스 SQL 카테고리로 지정합니다.

## Related Issue

- Closes #4
